### PR TITLE
fix: state visiblity for contracts

### DIFF
--- a/lib/commutative/U256Cum.sol
+++ b/lib/commutative/U256Cum.sol
@@ -58,7 +58,7 @@ contract U256Cumulative {
      * @notice Get the minimum bound of the cumulative variable.
      * @return The minimum bound of the cumulative variable.
      */
-    function min() public  returns(uint256) { 
+    function min() public view returns(uint256) { 
         (, bytes memory data) = address(API).staticcall(abi.encodeWithSignature("min()"));
         return abi.decode(data, (uint256));
     }  
@@ -67,7 +67,7 @@ contract U256Cumulative {
      * @notice Get the maximum bound of the cumulative variable.
      * @return The maximum bound of the cumulative variable.
      */
-    function max() public returns(uint256) { 
+    function max() public view returns(uint256) { 
         (, bytes memory data) = address(API).staticcall(abi.encodeWithSignature("max()"));
         return abi.decode(data, (uint256));
     }    

--- a/lib/commutative/u256Cum_test.sol
+++ b/lib/commutative/u256Cum_test.sol
@@ -107,7 +107,7 @@ contract MultiCummutative {
         visitCount2.add(88);
     }
 
-    function check() public{
+    function check() public view {
         require(visitCount1.get() == 10);
         require(visitCount2.get() == 108);
         require(visitCount3.get() == 66);

--- a/lib/map/HashU256Cum.sol
+++ b/lib/map/HashU256Cum.sol
@@ -54,8 +54,8 @@ contract HashU256Map is Base {
      * @return value The uint256 value associated with the key.
      */
     function get(bytes32 key) public returns(uint256 value){   
-        (bool exist,bytes memory data)=Base._get(abi.encodePacked(key));
-        if(exist)
+        (bool _exist,bytes memory data)=Base._get(abi.encodePacked(key));
+        if(_exist)
             return uint256(abi.decode(data,(bytes32)));
         else
             return uint256(0);
@@ -81,8 +81,8 @@ contract HashU256Map is Base {
      * @return value The value retrieved from the storage array at the given index.    
      */
     function valueAt(uint256 idx) public returns(uint256 value){ 
-        (bool exist,bytes memory data)=Base._get(idx);
-        if(exist)
+        (bool _exist,bytes memory data)=Base._get(idx);
+        if(_exist)
             return uint256(abi.decode(data, (bytes32)));
         else
             return uint256(0);

--- a/lib/map/StringUint256.sol
+++ b/lib/map/StringUint256.sol
@@ -38,8 +38,8 @@ contract StringUint256Map is Base {
      * @return value The string value associated with the key.
      */
     function get(string memory k) public virtual returns(uint256 value){ 
-        (bool exist,bytes memory data)=Base._get(bytes(k));
-        if(exist)
+        (bool _exist,bytes memory data)=Base._get(bytes(k));
+        if(_exist)
             return uint256(abi.decode(data, (bytes32)));     
         else
             return uint256(0);
@@ -60,8 +60,8 @@ contract StringUint256Map is Base {
      * @return value The value retrieved from the storage array at the given index.    
     */
     function valueAt(uint256 idx) public virtual returns(uint256 value){ 
-        (bool exist,bytes memory data)=Base._get(idx);
-        if(exist)
+        (bool _exist,bytes memory data)=Base._get(idx);
+        if(_exist)
             return uint256(abi.decode(data,(bytes32)));  
         else
             return uint256(0);

--- a/lib/map/U256.sol
+++ b/lib/map/U256.sol
@@ -38,8 +38,8 @@ contract U256Map is Base {
      * @return value The uint256 value associated with the key.
      */
     function get(uint256 key) public virtual returns(uint256 value){    
-        (bool exist,bytes memory data)= Base._get(abi.encodePacked(key));
-        if(exist)
+        (bool _exist,bytes memory data)= Base._get(abi.encodePacked(key));
+        if(_exist)
             return uint256(abi.decode(data, (bytes32)));
         else
             return uint256(0);
@@ -60,8 +60,8 @@ contract U256Map is Base {
      * @return value The value retrieved from the storage array at the given index.    
      */
     function valueAt(uint256 idx) public virtual returns(uint256 value){ 
-        (bool exist,bytes memory data)=Base._get(idx);
-        if(exist)
+        (bool _exist,bytes memory data)=Base._get(idx);
+        if(_exist)
             return  uint256(abi.decode(data, (bytes32)));
         else
             return uint256(0);


### PR DESCRIPTION
- Since I was getting linting errors via my `solhinter` settings , the origin was via these simple changes for state modifications and function overshadowing
This PR fixes the state modifier handling and function name overshadowing fix