### PR TITLE
feat(address-bytes-map): Add AddressBytesMap and Tests

### DIFF
--- a/lib/map/AddressBytes.sol
+++ b/lib/map/AddressBytes.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.7.0;
+
+import "../core/Const.sol";
+import "../core/Primitive.sol";
+
+/**
+ * @author Arcology Network
+ * @title AddressBytesMap Contract
+ * @dev The AddressBytesMap contract provides a simple mapping structure to associate
+ *      address keys with bytes values. It inherits from the "Base" contract
+ *      to utilize container functionalities for key-value storage.
+ */
+contract AddressBytesMap is Base {
+    constructor() Base(Const.BYTES, false) {}
+
+    /**
+     * @notice Check if a given key exists in the map.
+     * @param k The address key to check for existence.
+     * @return true if the key exists, false otherwise.
+     */
+    function exist(address k) public returns(bool) {
+        return Base.exists(abi.encodePacked(k));
+    }
+
+    /**
+     * @notice Set a key-value pair in the map.
+     * @param key The address key to set.
+     * @param value The bytes value to associate with the key.
+     */
+    function set(address key, bytes memory value) public {
+        Base._set(abi.encodePacked(key), value);
+    }
+
+    /**
+     * @notice Get the value associated with a given key in the map.
+     * @param key The address key to retrieve the associated value.
+     * @return value The bytes value associated with the key.
+     */
+    function get(address key) public virtual returns(bytes memory value) {
+        (bool ifExist, bytes memory data) = Base._get(abi.encodePacked(key));
+        if (ifExist)
+            return data;
+        else
+            return "";
+    }
+
+    /**
+     * @notice Get the key based on its index.
+     * @param idx The index to retrieve the associated key.
+     * @return The address key associated with the index.
+     */
+    function keyAt(uint256 idx) public virtual returns(address) {
+        bytes memory rawdata = Base.indToKey(idx);
+        bytes20 resultAdr;
+        for (uint i = 0; i < 20; i++) {
+            resultAdr |= bytes20(rawdata[i]) >> (i * 8);
+        }
+        return address(uint160(resultAdr));
+    }
+
+    /**
+     * @notice Retrieves the value stored at the specified index.
+     * @param idx The index of the element to retrieve.
+     * @return value The bytes value retrieved from the storage array at the given index.
+     */
+    function valueAt(uint256 idx) public virtual returns(bytes memory value) {
+        (bool ifExist, bytes memory data) = Base._get(idx);
+        if (ifExist)
+            return data;
+        else
+            return "";
+    }
+
+    /**
+     * @notice Delete a key-value pair from the map.
+     * @param key The address key to delete.
+     */
+    function del(address key) public returns(bool) {
+        return Base._del(abi.encodePacked(key));
+    }
+}

--- a/lib/map/addressBytes_test.sol
+++ b/lib/map/addressBytes_test.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.7.0;
+
+import "./AddressBytes.sol";
+
+contract AddressBytesMapTest {
+    AddressBytesMap map = new AddressBytesMap();
+    event LogBytes(address k, uint256 idx, bytes v);
+    event Step(address val);
+    constructor() {
+        address addr1 = 0x1111111110123456789012345678901234567890;
+        address addr2 = 0x2222222220123456789012345678901234567890;
+        address addr3 = 0x3333337890123456789012345678901234567890;
+        address addr4 = 0x4444444890123456789012345678901234567890;
+
+        require(map.exist(addr1) == false);
+        require(map.exist(addr2) == false);
+        require(map.exist(addr3) == false);
+        require(map.exist(addr4) == false);
+
+        map.set(addr1, hex"010203");
+        map.set(addr2, hex"aabbcc");
+        map.set(addr3, hex"deadbeef");
+        require(map.exist(addr1));
+        require(map.exist(addr2));
+        require(map.exist(addr3));
+        require(!map.exist(addr4));
+
+        require(keccak256(map.get(addr1)) == keccak256(hex"010203"));
+        require(keccak256(map.get(addr2)) == keccak256(hex"aabbcc"));
+        require(keccak256(map.get(addr3)) == keccak256(hex"deadbeef"));
+        require(keccak256(map.get(addr4)) == keccak256("") );
+
+        require(map.keyAt(0) == addr1);
+        require(map.keyAt(1) == addr2);
+        require(map.keyAt(2) == addr3);
+
+        map.del(addr1);
+        map.del(addr2);
+        map.del(addr3);
+        require(map.exist(addr1) == false);
+        require(map.exist(addr2) == false);
+        require(map.exist(addr3) == false);
+        require(map.exist(addr4) == false);
+    }
+}


### PR DESCRIPTION
This PR introduces a new concurrent map contract AddressBytesMap that maps address to bytes, following Arcology Network principles. It also adds a comprehensive test contract AddressBytes_test.sol to verify its core functionality.

### Changes
- Added AddressBytes.sol
- Implements a concurrent map from address to bytes using the Arcology Base container.
- Includes full documentation and Arcology-style comments.
- Added AddressBytes_test.sol
- Tests all major functions: set, get, exist, del, and keyAt.
- Follows the style and structure of other map contract tests.